### PR TITLE
Added new @iiif/parser/strict for converting P3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 .build
 .idea
 node_modules
+coverage

--- a/__tests__/presentation-3-parser/strict-upgrade.test.ts
+++ b/__tests__/presentation-3-parser/strict-upgrade.test.ts
@@ -1,0 +1,615 @@
+import { presentation3StrictUpgrade } from '../../src/presentation-3/strict-upgrade';
+import { Manifest } from '@iiif/presentation-3';
+
+function getBaseManifest(): Manifest {
+  return {
+    '@context': 'http://iiif.io/api/presentation/3/context.json',
+    id: 'https://iiif.io/api/cookbook/recipe/0001-mvm-image/manifest.json',
+    type: 'Manifest',
+    label: {
+      en: ['Image 1'],
+    },
+    items: [
+      {
+        id: 'https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1',
+        type: 'Canvas',
+        height: 1800,
+        width: 1200,
+        items: [
+          {
+            id: 'https://iiif.io/api/cookbook/recipe/0001-mvm-image/page/p1/1',
+            type: 'AnnotationPage',
+            items: [
+              {
+                id: 'https://iiif.io/api/cookbook/recipe/0001-mvm-image/annotation/p0001-image',
+                type: 'Annotation',
+                motivation: 'painting',
+                body: {
+                  id: 'http://iiif.io/api/presentation/2.1/example/fixtures/resources/page1-full.png',
+                  type: 'Image',
+                  format: 'image/png',
+                  height: 1800,
+                  width: 1200,
+                },
+                target: 'https://iiif.io/api/cookbook/recipe/0001-mvm-image/canvas/p1',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('Strict upgrade', () => {
+  test('Label as string', () => {
+    const manifest = {
+      id: 'https://example.org',
+      type: 'Manifest',
+      label: 'Wrong label',
+    };
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    expect(upgraded.label).toEqual({ none: ['Wrong label'] });
+    expect(state.warnings).toContain('"label" should be a language map instead found a string');
+  });
+  test('Label without language', () => {
+    const manifest = {
+      id: 'https://example.org',
+      type: 'Manifest',
+      label: ['Wrong label'],
+    };
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    expect(upgraded.label).toEqual({ none: ['Wrong label'] });
+    expect(state.warnings).toContain('"label" should be a language map instead found a string');
+  });
+  test('Label missing array values', () => {
+    const manifest = {
+      id: 'https://example.org',
+      type: 'Manifest',
+      label: { en: 'Wrong label' },
+    };
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    expect(upgraded.label).toEqual({ en: ['Wrong label'] });
+    expect(state.warnings).toContain(
+      '"label" values inside a language map should be an Array of strings, found a string'
+    );
+  });
+  test('Label empty array', () => {
+    const manifest = {
+      id: 'https://example.org',
+      type: 'Manifest',
+      label: [],
+    };
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    expect(upgraded.label).toEqual({ none: [''] });
+    expect(state.warnings).toContain('"label" should be a language map instead found an unknown value');
+  });
+  test('Label invalid values', () => {
+    const manifest = {
+      id: 'https://example.org',
+      type: 'Manifest',
+      label: {
+        en: { INVALID: 'this is not valid' },
+      },
+    };
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    expect(upgraded.label).toEqual({ none: [''] });
+    expect(state.warnings).toContain(
+      '"label" values inside a language map should be an Array of strings, found an unknown value'
+    );
+  });
+  test('Label invalid values (object)', () => {
+    const manifest = {
+      id: 'https://example.org',
+      type: 'Manifest',
+      label: {
+        de: [{ INVALID: 'this is not valid' }],
+      },
+    };
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    expect(upgraded.label).toEqual({ none: [''] });
+    expect(state.warnings).toContain(
+      '"label" values inside a language map should be an Array of strings, found an unknown value'
+    );
+  });
+  test('Incorrect format', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].items[0].items[0].body.format = ['image/png'];
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].items[0].items[0].body.format).toEqual('image/png');
+    expect(state.warnings).toContain('"format" should be a single string');
+  });
+  test('Invalid format', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].items[0].items[0].body.format = [{ type: 'image/png' }];
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].items[0].items[0].body.format).toBeUndefined();
+    expect(state.warnings).toContain('"format" should be a single string');
+  });
+  test('Invalid behavior', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.behavior = 'paged';
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.behavior).toEqual(['paged']);
+    expect(state.warnings).toContain('"behavior" should be Array of values');
+  });
+  test('Invalid height/width (float)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].height += 0.5;
+    // @ts-ignore
+    manifest.items[0].width += 0.5;
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].height).toEqual(1800);
+    // @ts-ignore
+    expect(upgraded.items[0].width).toEqual(1200);
+    expect(state.warnings).toContain('"width" expected value to be a Integer, instead found a Float');
+    expect(state.warnings).toContain('"height" expected value to be a Integer, instead found a Float');
+  });
+  test('Invalid height/width (string)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].height = `${manifest.items[0].height}`;
+    // @ts-ignore
+    manifest.items[0].width = `${manifest.items[0].width}`;
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].height).toEqual(1800);
+    // @ts-ignore
+    expect(upgraded.items[0].width).toEqual(1200);
+    expect(state.warnings).toContain('"width" expected value to be a Integer, instead found a string');
+    expect(state.warnings).toContain('"height" expected value to be a Integer, instead found a string');
+  });
+  test('Invalid height/width (NaN)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].height = `abc`;
+    // @ts-ignore
+    manifest.items[0].width = `abc`;
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].height).toBeUndefined();
+    // @ts-ignore
+    expect(upgraded.items[0].width).toBeUndefined();
+    expect(state.warnings).toContain('"width" expected value to be a Integer, instead found an invalid value');
+    expect(state.warnings).toContain('"height" expected value to be a Integer, instead found an invalid value');
+  });
+  test('Invalid duration (string)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].duration = `12.34`;
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].duration).toEqual(12.34);
+    expect(state.warnings).toContain('"duration" expected value to be a Number, instead found a string');
+  });
+  test('Invalid duration (NaN)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].duration = `NOT A NUMBER`;
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].duration).toBeUndefined();
+    expect(state.warnings).toContain('"duration" expected value to be a Number, instead found an invalid value');
+  });
+  test('Invalid summary', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].summary = `This is invalid`;
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].summary).toEqual({ none: ['This is invalid'] });
+    expect(state.warnings).toContain('"summary" should be a language map instead found a string');
+  });
+
+  test('Invalid required statement (just string)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].requiredStatement = 'This is a required statement';
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].requiredStatement).toEqual({
+      label: { none: ['Required statement'] },
+      value: { none: ['This is a required statement'] },
+    });
+    expect(state.warnings).toContain('"requiredStatement" should be a {label, value} set of Language maps');
+  });
+  test('Invalid required statement (just value)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].requiredStatement = { value: 'This is a required statement' };
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].requiredStatement).toEqual({
+      label: { none: ['Required statement'] },
+      value: { none: ['This is a required statement'] },
+    });
+    expect(state.warnings).toContain('"requiredStatement" should have both a label and a value');
+    expect(state.warnings).toContain('"requiredStatement.value" should be a language map instead found a string');
+  });
+  test('Invalid metadata (just string)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].metadata = 'This is some metadata';
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].metadata).toEqual([]);
+    expect(state.warnings).toContain('"metadata" should be an array of {label, value} Language maps');
+  });
+  test('Invalid metadata (just value)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].metadata = { value: 'This is some metadata' };
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].metadata).toEqual([]);
+    expect(state.warnings).toContain('"metadata" should be an array of {label, value} Language maps');
+  });
+  test('Invalid metadata (single, only value)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.items[0].metadata = [{ value: 'This is some metadata' }];
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.items[0].metadata).toEqual([
+      {
+        label: { none: [''] },
+        value: { none: ['This is some metadata'] },
+      },
+    ]);
+    expect(state.warnings).toContain('"metadata.0" should have both a label and a value');
+    expect(state.warnings).toContain('"metadata.0.value" should be a language map instead found a string');
+  });
+  test('Invalid rights statement (https)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.rights = 'https://creativecommons.org/licenses/by/4.0/';
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.rights).toEqual('http://creativecommons.org/licenses/by/4.0/');
+    expect(state.warnings).toMatchInlineSnapshot(`
+      Array [
+        "\\"rights\\" is an informative property and should contain the http variation of the rights statement",
+      ]
+    `);
+  });
+  test('Invalid rights statement (array + https)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.rights = ['https://creativecommons.org/licenses/by/4.0/'];
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.rights).toEqual('http://creativecommons.org/licenses/by/4.0/');
+    expect(state.warnings).toMatchInlineSnapshot(`
+      Array [
+        "\\"rights\\" should only contain a single string",
+        "\\"rights\\" is an informative property and should contain the http variation of the rights statement",
+      ]
+    `);
+  });
+  test('Invalid rights statement (invalid)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.rights = 'This is not valid';
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.rights).toEqual('This is not valid');
+    expect(state.warnings).toMatchInlineSnapshot(`
+      Array [
+        "\\"rights\\" should be a valid URI",
+      ]
+    `);
+  });
+  test('Invalid navDate (invalid)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.navDate = '2020:01:02';
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.navDate).toBeUndefined();
+    expect(state.warnings).toMatchInlineSnapshot(`
+      Array [
+        "\\"navDate\\" should be a valid XSD dateTime literal",
+      ]
+    `);
+  });
+  test('Valid navDate', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.navDate = '2010-01-01T00:00:00Z';
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.navDate).toEqual('2010-01-01T00:00:00Z');
+    expect(state.warnings).toHaveLength(0);
+  });
+  test('Invalid navDate (whitespace)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.navDate = ' 2010-01-01T00:00:00Z   ';
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.navDate).toEqual('2010-01-01T00:00:00Z');
+    expect(state.warnings).toMatchInlineSnapshot(`
+      Array [
+        "\\"navDate\\" should not contain extra whitespace",
+      ]
+    `);
+  });
+  test('Invalid language (string)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.language = 'en';
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(manifest.language).toEqual(['en']);
+    expect(state.warnings).toMatchInlineSnapshot(`
+      Array [
+        "\\"language\\" should be Array of values",
+      ]
+    `);
+  });
+  test('Invalid language (other)', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.language = { lang: 'en' };
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.language).toEqual([]);
+    expect(state.warnings).toMatchInlineSnapshot(`
+      Array [
+        "\\"language\\" should be Array of values",
+        "'\\"language\\" expected array of strings",
+      ]
+    `);
+  });
+  test('Valid language', () => {
+    const manifest = getBaseManifest();
+
+    // @ts-ignore
+    manifest.language = ['en', 'fr'];
+
+    const state = { warnings: [] as string[] };
+    const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+    // @ts-ignore
+    expect(upgraded.language).toEqual(['en', 'fr']);
+    expect(state.warnings).toHaveLength(0);
+  });
+
+  describe('Accompanying canvas', () => {
+    function getAccCanvas() {
+      return {
+        '@context': 'http://iiif.io/api/presentation/3/context.json',
+        id: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/manifest.json',
+        type: 'Manifest',
+        label: {
+          en: ["Partial audio recording of Gustav Mahler's _Symphony No. 3_"],
+        },
+        items: [
+          {
+            id: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/p1',
+            type: 'Canvas',
+            label: {
+              en: ['Gustav Mahler, Symphony No. 3, CD 1'],
+            },
+            duration: 1985.024,
+            accompanyingCanvas: {
+              id: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying',
+              type: 'Canvas',
+              label: {
+                en: ['First page of score for Gustav Mahler, Symphony No. 3'],
+              },
+              height: 998,
+              width: 772,
+              items: [
+                {
+                  id: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/page',
+                  type: 'AnnotationPage',
+                  items: [
+                    {
+                      id: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying/annotation/image',
+                      type: 'Annotation',
+                      motivation: 'painting',
+                      body: {
+                        id: 'https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0/full/,998/0/default.jpg',
+                        type: 'Image',
+                        format: 'image/jpeg',
+                        height: 998,
+                        width: 772,
+                        service: [
+                          {
+                            id: 'https://iiif.io/api/image/3.0/example/reference/4b45bba3ea612ee46f5371ce84dbcd89-mahler-0',
+                            type: 'ImageService3',
+                            profile: 'level1',
+                          },
+                        ],
+                      },
+                      target: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/accompanying',
+                    },
+                  ],
+                },
+              ],
+            },
+            items: [
+              {
+                id: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1',
+                type: 'AnnotationPage',
+                items: [
+                  {
+                    id: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/annotation/segment1-audio',
+                    type: 'Annotation',
+                    motivation: 'painting',
+                    body: {
+                      id: 'https://fixtures.iiif.io/audio/indiana/mahler-symphony-3/CD1/medium/128Kbps.mp4',
+                      type: 'Sound',
+                      duration: 1985.024,
+                      format: 'video/mp4',
+                    },
+                    target: 'https://iiif.io/api/cookbook/recipe/0014-accompanyingcanvas/canvas/page/p1',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+    }
+
+    test('valid case', () => {
+      const manifest = getAccCanvas();
+
+      const state = { warnings: [] as string[] };
+      const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+      // @ts-ignore
+      expect(state.warnings).toHaveLength(0);
+    });
+    test('invalid case', () => {
+      const manifest = getAccCanvas();
+      const manifestCorrect = getAccCanvas();
+
+      // @ts-ignore
+      manifest.items[0].accompanyingCanvas = [manifest.items[0].accompanyingCanvas];
+
+      const state = { warnings: [] as string[] };
+      const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+      // @ts-ignore
+      expect(upgraded.items[0].accompanyingCanvas).toEqual(manifestCorrect.items[0].accompanyingCanvas);
+      expect(state.warnings).toMatchInlineSnapshot(`
+        Array [
+          "\\"accompanyingCanvas\\" should only contain a single value",
+        ]
+      `);
+    });
+    test('not type Canvas', () => {
+      const manifest = getAccCanvas();
+
+      // @ts-ignore
+      manifest.items[0].accompanyingCanvas.type = 'NotCanvas';
+
+      const state = { warnings: [] as string[] };
+      const upgraded = presentation3StrictUpgrade(manifest as any, state);
+
+      // @ts-ignore
+      expect(state.warnings).toMatchInlineSnapshot(`
+        Array [
+          "\\"accompanyingCanvas\\" should be a Canvas",
+        ]
+      `);
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
       "import": "./dist/esm/index.mjs",
       "default": "./dist/index.umd.js"
     },
+    "./strict": {
+      "require": "./dist/strict/cjs/index.js",
+      "import": "./dist/strict/esm/index.mjs",
+      "default": "./dist/strict/index.umd.js"
+    },
     "./upgrader": "./dist/upgrader/index.umd.js"
   },
   "typesVersions": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,10 @@ export default [
     dist: './dist/presentation-2/index.d.ts',
   }),
   createTypeConfig({
+    source: './.build/types/presentation-3/strict-upgrade.d.ts',
+    dist: './dist/strict/index.d.ts',
+  }),
+  createTypeConfig({
     source: './.build/types/upgrader.d.ts',
     dist: './dist/upgrader/index.d.ts',
   }),
@@ -55,6 +59,20 @@ export default [
     ...baseConfig,
     dist: 'dist/presentation-2',
     input: './src/presentation-2/index.ts',
+    distPreset: 'cjs',
+  }),
+
+  // import {} from '@iiif/parser/strict';
+  createRollupConfig({
+    ...baseConfig,
+    dist: 'dist/strict',
+    input: './src/presentation-3/strict-upgrade.ts',
+    distPreset: 'esm',
+  }),
+  createRollupConfig({
+    ...baseConfig,
+    dist: 'dist/strict',
+    input: './src/presentation-3/strict-upgrade.ts',
     distPreset: 'cjs',
   }),
 

--- a/src/presentation-2/upgrader.ts
+++ b/src/presentation-2/upgrader.ts
@@ -2,6 +2,8 @@ import * as Presentation3 from '@iiif/presentation-3';
 import * as Presentation2 from '@iiif/presentation-2';
 import { imageServiceProfiles, level1Support } from '../shared/image-api-profiles';
 import { Traverse } from './traverse';
+import { ensureArray } from '../shared/ensure-array';
+import { removeUndefinedProperties } from "../shared/remove-undefined-properties";
 
 const configuration = {
   attributionLabel: 'Attribution',
@@ -117,13 +119,6 @@ function getTypeFromProfile(inputProfile: string): string | undefined {
   }
 
   return undefined;
-}
-
-function ensureArray<T>(maybeArray: T | T[]): T[] {
-  if (Array.isArray(maybeArray)) {
-    return maybeArray;
-  }
-  return [maybeArray];
 }
 
 function removePrefix(str: string) {
@@ -326,15 +321,6 @@ function convertMetadata(
       value: convertLanguageMapping(item.value),
     };
   });
-}
-
-function removeUndefinedProperties(obj: any) {
-  for (const prop in obj) {
-    if (typeof obj[prop] === 'undefined' || obj[prop] === null) {
-      delete obj[prop];
-    }
-  }
-  return obj;
 }
 
 let mintedIdCounter = 0;

--- a/src/presentation-3/strict-upgrade.ts
+++ b/src/presentation-3/strict-upgrade.ts
@@ -1,0 +1,387 @@
+import * as Presentation3 from '@iiif/presentation-3';
+import { Traverse } from './traverse';
+import { removeUndefinedProperties } from '../shared/remove-undefined-properties';
+
+const validNavDate =
+  /-?([1-9]\d{3,}|0\d{3})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T(([01]\d|2[0-3]):[0-5]\d:[0-5]\d(\.\d+)?|(24:00:00(\.0+)?))(Z|(\+|-)((0\d|1[0-3]):[0-5]\d|14:00))?/;
+
+interface InternalLogging {
+  warnings: string[];
+}
+
+const globalWarnings = { warnings: [] };
+
+function technicalProperties(
+  item: Partial<Presentation3.TechnicalProperties>,
+  logging: InternalLogging = globalWarnings
+): Partial<Presentation3.TechnicalProperties> {
+  if (item.behavior) {
+    item.behavior = ensureArrayWarning(item.behavior, 'behavior', logging);
+  }
+
+  item.width = ensureValidNumber(item.width, 'width', false, logging);
+  item.height = ensureValidNumber(item.height, 'height', false, logging);
+  item.duration = ensureValidNumber(item.duration, 'duration', true, logging);
+
+  if (item.format && typeof item.format !== 'string') {
+    logging.warnings.push(`"format" should be a single string`);
+    if (Array.isArray(item.format) && typeof item.format[0] === 'string') {
+      item.format = item.format[0];
+    } else {
+      item.format = undefined;
+    }
+  }
+
+  return item;
+}
+
+function ensureArrayMatches(
+  values: Array<any> | undefined,
+  isValid: (value: any) => string | undefined,
+  logging: InternalLogging = globalWarnings
+) {
+  if (values && Array.isArray(values)) {
+    return values.filter((value) => {
+      const message = isValid(value);
+      if (message && logging.warnings.indexOf(message) === -1) {
+        logging.warnings.push(message);
+      }
+      return !message;
+    });
+  }
+  return values;
+}
+
+function ensureArrayWarning(value: any, propName: string, logging: InternalLogging = globalWarnings) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  logging.warnings.push(`"${propName}" should be Array of values`);
+  return [value];
+}
+
+function ensureNotArrayWarning(value: any, propName: string, logging: InternalLogging = globalWarnings) {
+  if (Array.isArray(value)) {
+    logging.warnings.push(`"${propName}" should only contain a single value`);
+    if (value.length === 0) {
+      return undefined;
+    }
+    return value[0];
+  }
+  return value;
+}
+
+function ensureValidNumber(
+  value: undefined | string | number,
+  propName: string,
+  isFloat = false,
+  logging: InternalLogging = globalWarnings
+): number | undefined {
+  if (typeof value === 'undefined') {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    const newValue = isFloat ? parseFloat(value) : Math.abs(Number(value));
+    if (Number.isNaN(newValue) || newValue <= 0) {
+      logging.warnings.push(
+        `"${propName}" expected value to be a ${isFloat ? 'Number' : 'Integer'}, instead found an invalid value`
+      );
+      return undefined;
+    }
+    logging.warnings.push(
+      `"${propName}" expected value to be a ${isFloat ? 'Number' : 'Integer'}, instead found a string`
+    );
+    return newValue;
+  }
+
+  if (!isFloat && value % 1 !== 0) {
+    logging.warnings.push(`"${propName}" expected value to be a Integer, instead found a Float`);
+    return Math.floor(value);
+  }
+
+  return value;
+}
+
+function ensureValidLanguageMap(
+  str: Presentation3.InternationalString,
+  propName: string,
+  logging: InternalLogging = globalWarnings
+): Presentation3.InternationalString {
+  // Handle {"label": ["an array of strings"]}
+  if (Array.isArray(str)) {
+    if (typeof str[0] === 'string') {
+      logging.warnings.push(`"${propName}" should be a language map instead found a string`);
+      return { none: str };
+    }
+    logging.warnings.push(`"${propName}" should be a language map instead found an unknown value`);
+    return { none: [''] };
+  }
+
+  if (typeof str === 'string') {
+    logging.warnings.push(`"${propName}" should be a language map instead found a string`);
+    return { none: [str] };
+  }
+
+  // Handle {"label": {"en": "some value"}
+  const keys = Object.keys(str);
+  const fixed: Presentation3.InternationalString = {};
+  let didFix = false;
+  for (const key of keys) {
+    const values = str[key] as unknown;
+    const fixedItem = [];
+    if (typeof values === 'string') {
+      didFix = true;
+      logging.warnings.push(`"${propName}" values inside a language map should be an Array of strings, found a string`);
+      fixedItem.push(values);
+    } else if (Array.isArray(values)) {
+      for (const str of values) {
+        if (!(typeof str === 'string')) {
+          didFix = true;
+          logging.warnings.push(
+            `"${propName}" values inside a language map should be an Array of strings, found an unknown value`
+          );
+          // Nothing to do here? - but mark as needing fixed.
+        } else {
+          fixedItem.push(str);
+        }
+      }
+    } else {
+      didFix = true;
+      logging.warnings.push(
+        `"${propName}" values inside a language map should be an Array of strings, found an unknown value`
+      );
+    }
+    if (fixedItem.length > 0) {
+      fixed[key] = fixedItem;
+    }
+  }
+
+  if (didFix) {
+    if (Object.keys(fixed).length === 0) {
+      return { none: [''] };
+    }
+
+    return fixed;
+  }
+
+  return str;
+}
+
+function validMetadataValue(
+  input: Presentation3.MetadataItem,
+  propName: string,
+  defaultLabel = '',
+  logging: InternalLogging = globalWarnings
+): Presentation3.MetadataItem {
+  if (typeof input === 'string') {
+    logging.warnings.push(`"${propName}" should be a {label, value} set of Language maps`);
+    return {
+      label: { none: [defaultLabel] },
+      value: { none: [input] },
+    };
+  } else {
+    if ((!input.label && input.value) || (input.label && !input.value)) {
+      logging.warnings.push(`"${propName}" should have both a label and a value`);
+    }
+    if (input.label) {
+      input.label = ensureValidLanguageMap(input.label, `${propName}.label`, logging);
+    } else {
+      input.label = { none: [defaultLabel] };
+    }
+    if (input.value) {
+      input.value = ensureValidLanguageMap(input.value, `${propName}.value`, logging);
+    } else {
+      input.value = { none: [''] };
+    }
+  }
+
+  return input;
+}
+
+function descriptiveProperties(
+  item: Partial<Presentation3.DescriptiveProperties>,
+  logging: InternalLogging = globalWarnings
+): Partial<Presentation3.DescriptiveProperties> {
+  if (item.label) {
+    item.label = ensureValidLanguageMap(item.label, 'label', logging);
+  }
+  if (item.summary) {
+    item.summary = ensureValidLanguageMap(item.summary, 'summary', logging);
+  }
+
+  if (item.requiredStatement) {
+    item.requiredStatement = validMetadataValue(
+      item.requiredStatement,
+      'requiredStatement',
+      'Required statement',
+      logging
+    );
+  }
+
+  if (item.metadata) {
+    if (Array.isArray(item.metadata)) {
+      for (let i = 0; i < item.metadata.length; i++) {
+        item.metadata[i] = validMetadataValue(item.metadata[i], `metadata.${i}`, '', logging);
+      }
+    } else {
+      logging.warnings.push(`"metadata" should be an array of {label, value} Language maps`);
+      item.metadata = [];
+    }
+  }
+
+  if (item.rights) {
+    if (Array.isArray(item.rights)) {
+      logging.warnings.push(`"rights" should only contain a single string`);
+      item.rights = typeof item.rights[0] === 'string' ? item.rights[0] : '';
+    }
+    if (typeof item.rights === 'string' && !item.rights.startsWith('http')) {
+      logging.warnings.push(`"rights" should be a valid URI`);
+    } else if (typeof item.rights === 'string' && item.rights.startsWith('https')) {
+      logging.warnings.push(
+        `"rights" is an informative property and should contain the http variation of the rights statement`
+      );
+      item.rights = `http${item.rights.slice(5)}`;
+    }
+  }
+
+  if (item.navDate) {
+    const trimmedNavDate = typeof item.navDate === 'string' ? item.navDate.trim() : undefined;
+    if (trimmedNavDate !== item.navDate) {
+      logging.warnings.push(`"navDate" should not contain extra whitespace`);
+      item.navDate = trimmedNavDate;
+    }
+    if (typeof item.navDate !== 'string' || !item.navDate.match(validNavDate)) {
+      logging.warnings.push(`"navDate" should be a valid XSD dateTime literal`);
+      item.navDate = undefined;
+    }
+  }
+
+  if (item.language) {
+    item.language = ensureArrayWarning(item.language, 'language', logging);
+    item.language = ensureArrayMatches(
+      item.language,
+      (value) => (typeof value === 'string' ? undefined : `'"language" expected array of strings`),
+      logging
+    );
+  }
+  if (item.accompanyingCanvas) {
+    item.accompanyingCanvas = ensureNotArrayWarning(item.accompanyingCanvas, 'accompanyingCanvas', logging);
+    if (item.accompanyingCanvas?.type !== 'Canvas') {
+      logging.warnings.push(`"accompanyingCanvas" should be a Canvas`);
+    }
+  }
+  if (item.placeholderCanvas) {
+    item.placeholderCanvas = ensureNotArrayWarning(item.placeholderCanvas, 'placeholderCanvas', logging);
+    if (item.placeholderCanvas?.type !== 'Canvas') {
+      logging.warnings.push(`"placeholderCanvas" should be a Canvas`);
+    }
+  }
+  if (item.thumbnail) {
+    item.thumbnail = ensureArrayWarning(item.thumbnail, 'thumbnail', logging);
+  }
+  return item;
+}
+
+const validItemMapping: any = {
+  Manifest: 'Canvas',
+  Canvas: 'AnnotationPage',
+  AnnotationPage: 'Annotation',
+};
+
+function structuralProperties(resource: any, logging: InternalLogging = globalWarnings) {
+  const type = resource.type;
+  switch (type) {
+    case 'Canvas':
+    case 'AnnotationPage':
+    case 'Manifest': {
+      if (resource && resource.items) {
+        resource.items = ensureArrayMatches(
+          resource.items,
+          (item) =>
+            item.type === validItemMapping[type]
+              ? undefined
+              : `"${resource.type}.items" should contain only type ${validItemMapping[type]}, found ${item.type}`,
+          logging
+        );
+      }
+    }
+  }
+
+  return resource;
+}
+
+function linkingProperties(
+  item: Partial<Presentation3.LinkingProperties>,
+  logging: InternalLogging = globalWarnings
+): Partial<Presentation3.LinkingProperties> {
+  if (item.logo) {
+    item.logo = ensureArrayWarning(item.logo, 'logo', logging);
+  }
+  if (item.service) {
+    item.service = ensureArrayWarning(item.service, 'service', logging);
+  }
+
+  if (item.seeAlso) {
+    item.seeAlso = ensureArrayWarning(item.seeAlso, 'seeAlso', logging);
+  }
+
+  if (item.rendering) {
+    item.rendering = ensureArrayWarning(item.rendering, 'rendering', logging);
+  }
+
+  if (item.partOf) {
+    item.partOf = ensureArrayWarning(item.partOf, 'partOf', logging);
+  }
+
+  if (item.homepage) {
+    item.homepage = ensureArrayWarning(item.homepage, 'homepage', logging);
+  }
+
+  if (item.services) {
+    item.services = ensureArrayWarning(item.services, 'services', logging);
+  }
+
+  if (item.supplementary) {
+    item.supplementary = ensureArrayWarning(item.supplementary, 'supplementary', logging);
+  }
+
+  if (item.start) {
+    item.start = ensureNotArrayWarning(item.start, 'start', logging);
+  }
+
+  return item;
+}
+
+function upgradeResource(state: InternalLogging) {
+  return (resource: any) => {
+    if (!resource) {
+      return undefined;
+    }
+
+    if (typeof resource === 'string') {
+      return resource;
+    }
+
+    if (Array.isArray(resource)) {
+      return resource;
+    }
+
+    return removeUndefinedProperties({
+      ...resource,
+      ...technicalProperties(resource, state),
+      ...descriptiveProperties(resource, state),
+      ...linkingProperties(resource, state),
+      ...structuralProperties(resource, state),
+    });
+  };
+}
+
+export function presentation3StrictUpgrade(
+  p3: Presentation3.Manifest,
+  state: InternalLogging = globalWarnings
+): Presentation3.Manifest {
+  const traverse = Traverse.all(upgradeResource(state));
+
+  return traverse.traverseManifest(p3);
+}

--- a/src/shared/ensure-array.ts
+++ b/src/shared/ensure-array.ts
@@ -1,0 +1,6 @@
+export function ensureArray<T>(maybeArray: T | T[]): T[] {
+  if (Array.isArray(maybeArray)) {
+    return maybeArray;
+  }
+  return [maybeArray];
+}

--- a/src/shared/remove-undefined-properties.ts
+++ b/src/shared/remove-undefined-properties.ts
@@ -1,0 +1,8 @@
+export function removeUndefinedProperties(obj: any) {
+  for (const prop in obj) {
+    if (typeof obj[prop] === 'undefined' || obj[prop] === null) {
+      delete obj[prop];
+    }
+  }
+  return obj;
+}


### PR DESCRIPTION
Adds new utility for validating and fixing Presentation 3 that may not be valid.

Note: this will not automatically upgrade Presentation 2.
```ts
import { presentation3StrictUpgrade } from '@iiif/parser/strict';

const manifest = fetch('https://example.org/manifest').then(r => r.json());

const upgradedManifest = presentation3StrictUpgrade(manifest);

// Should now be valid Presentation 3
```

You can also get a list of issues with the second argument.
```ts
const manifest = {
  id: 'https://example.org',
  type: 'Manifest',
  label: 'Wrong label',
};

const state = { warnings: [] as string[] };
const upgraded = presentation3StrictUpgrade(manifest as any, state);

upgraded.label; // { none: ['Wrong label'] }
state.warnings[0]; // "label" should be a language map instead found a string
```

**Currently supported:**
* Various invalid language map formats
  * single strings `{"label": "some label"}`
  * arrays of strings `{"label": ["some label"]}`
  * maps without values `{"label": {"en": "some label"}}`
  * maps with objects `{"label": { en: { INVALID: 'this is not valid' } }}`
* Properties that should be arrays are wrapped (e.g. `behavior`) 
* Properties that shouldn't be arrays are unwrapped (e.g. `format`)
* Ensures that `heights` and `widths` are JSON numbers and not floats
* Ensures that `duration` is a valid float
* Ensures that required statements and metadata have both labels and values
* Ensures rights statement starts with `http` (may be flaky with custom values)
* Validates navDate against regular expression from W3C (and removes whitespace)
* Ensures Manifests only contain Canvases
* Ensures Canvases only contain Annotation Pages
* Ensures Annotation Pages only contain Annotations
* Ensures accompanyingCanvas and placeholderCanvas are type Canvas (only warning)

This is built to be expanded on, and improved if there are other common pitfalls out there. Any fix should be accompanied with a descriptive warning that can be picked up. This allows it to be used both for compatibility and for validation.

There are also other possible validations that may not be possible to fix, but could be worth warning:
* Duration on a canvas without duration supporting resources
* Image resources without height/width
* Audio/Video without duration
* Audio/Video with duration that is out of bounds
* Painting Annotations that target different canvases
