### PR TITLE
Fix IIIFv2 `AnnotationList` type prefix from `oa:` to `sc:`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@iiif/presentation-2": "^1.0.2",
+    "@iiif/presentation-2": "^1.0.3",
     "@iiif/presentation-3": "^1.1.3",
     "@types/geojson": "^7946.0.8"
   },

--- a/src/presentation-2/traverse.ts
+++ b/src/presentation-2/traverse.ts
@@ -24,7 +24,7 @@ export const types: TraversableEntityTypes[] = [
   'sc:Collection',
   'sc:Manifest',
   'sc:Canvas',
-  'oa:AnnotationList',
+  'sc:AnnotationList',
   'oa:Annotation',
   'sc:Range',
   'sc:Layer',
@@ -289,7 +289,7 @@ export class Traverse<
   traverseAnnotationList(annotationList: AnnotationList): T['AnnotationList'] {
     const list =
       typeof annotationList === 'string'
-        ? ({ '@id': annotationList, '@type': 'oa:AnnotationList' } as any)
+        ? ({ '@id': annotationList, '@type': 'sc:AnnotationList' } as any)
         : annotationList;
 
     return this.traverseType(
@@ -385,7 +385,7 @@ export class Traverse<
         return this.traverseRange(item);
       case 'oa:Annotation':
         return this.traverseAnnotation(item);
-      case 'oa:AnnotationList':
+      case 'sc:AnnotationList':
         return this.traverseAnnotationList(item);
       case 'sc:Layer':
         return this.traverseLayer(item);

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,10 +370,10 @@
   dependencies:
     ajv "6.12.2"
 
-"@iiif/presentation-2@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@iiif/presentation-2/-/presentation-2-1.0.2.tgz#c712c4a40cc5b7291b8d92646b0ec8b8215b9b3d"
-  integrity sha512-EN/p+td5VrHvUsQXV26VkaDFW0HG2GPRaibPlxJRip8au8ABBrOYPIcBH69Hyk3I0UnW3xzK2VsZ9TcuQEn0Mw==
+"@iiif/presentation-2@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@iiif/presentation-2/-/presentation-2-1.0.3.tgz#dd2af09befcecb8e0d5e1579dd27d0241ab1aaa7"
+  integrity sha512-erIXmedqXmJ0PnEXDaAdmUqwb7a22FPQQ783/vOY3sfoe3Lf4pzK5l2zxUMT6L/roFSgHPhGTT5hbt7pBOVt1g==
 
 "@iiif/presentation-3@^1.1.3":
   version "1.1.3"


### PR DESCRIPTION
This seems to have been a misreading of the IIIFv2 spec, which clearly states that an annotation list must have the type `sc:AnnotationList`.

Requires this corresponding fix in the `presentation-2-types`: https://github.com/IIIF-Commons/presentation-2-types/pull/3