### PR TITLE
fix(presentation-2): do not double-encode percent-escaped identifiers

### DIFF
--- a/__tests__/presentation-2-parser/upgrade.test.ts
+++ b/__tests__/presentation-2-parser/upgrade.test.ts
@@ -2650,4 +2650,100 @@ describe("Presentation 2 to 3", () => {
     expect(collection.type).toEqual("Collection");
     expect(collection.items?.[0].type).toEqual("Manifest");
   });
+  test("does not double-encode percent-escaped identifiers", () => {
+    // IIIF Image API identifiers often contain a slash encoded as %2F.
+    // Re-encoding turns that into %252F, which no image server can resolve.
+    const serviceId = "https://example.org/iiif/3/book%2Fpage%2F0001.tif";
+    const imageId = `${serviceId}/full/max/0/default.jpg`;
+
+    const result = convertPresentation2({
+      "@context": "http://iiif.io/api/presentation/2/context.json",
+      "@id": "https://example.org/manifest",
+      "@type": "sc:Manifest",
+      label: "Percent-encoded identifiers",
+      sequences: [
+        {
+          "@id": "https://example.org/sequence",
+          "@type": "sc:Sequence",
+          canvases: [
+            {
+              "@id": "https://example.org/canvas/1",
+              "@type": "sc:Canvas",
+              label: "1",
+              width: 1000,
+              height: 1000,
+              images: [
+                {
+                  "@id": "https://example.org/annotation/1",
+                  "@type": "oa:Annotation",
+                  motivation: "sc:painting",
+                  on: "https://example.org/canvas/1",
+                  resource: {
+                    "@id": imageId,
+                    "@type": "dctypes:Image",
+                    format: "image/jpeg",
+                    width: 1000,
+                    height: 1000,
+                    service: {
+                      "@context": "http://iiif.io/api/image/2/context.json",
+                      "@id": serviceId,
+                      profile: "http://iiif.io/api/image/2/level2.json",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as any) as any;
+
+    const body = result.items[0].items[0].items[0].body;
+
+    expect(body.id).toEqual(imageId);
+    expect(body.id).not.toContain("%252F");
+  });
+
+  test("still encodes characters that are not escaped", () => {
+    const result = convertPresentation2({
+      "@context": "http://iiif.io/api/presentation/2/context.json",
+      "@id": "https://example.org/manifest",
+      "@type": "sc:Manifest",
+      label: "Unescaped characters",
+      sequences: [
+        {
+          "@id": "https://example.org/sequence",
+          "@type": "sc:Sequence",
+          canvases: [
+            {
+              "@id": "https://example.org/canvas/1",
+              "@type": "sc:Canvas",
+              label: "1",
+              width: 1000,
+              height: 1000,
+              images: [
+                {
+                  "@id": "https://example.org/annotation/1",
+                  "@type": "oa:Annotation",
+                  motivation: "sc:painting",
+                  on: "https://example.org/canvas/1",
+                  resource: {
+                    "@id": "https://example.org/iiif/3/a b.tif/full/max/0/default.jpg",
+                    "@type": "dctypes:Image",
+                    format: "image/jpeg",
+                    width: 1000,
+                    height: 1000,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } as any) as any;
+
+    expect(result.items[0].items[0].items[0].body.id).toEqual(
+      "https://example.org/iiif/3/a%20b.tif/full/max/0/default.jpg"
+    );
+  });
 });

--- a/src/presentation-2/upgrader.ts
+++ b/src/presentation-2/upgrader.ts
@@ -358,11 +358,27 @@ function convertMetadata(
 
 let mintedIdCounter = 0;
 
+/**
+ * Encode a URI without corrupting percent-escapes that are already present.
+ *
+ * `encodeURI` escapes a literal `%`, so calling it on a URI that is already
+ * encoded turns `%2F` into `%252F`. IIIF Image API identifiers routinely
+ * contain `%2F` (a slash inside the identifier), so re-encoding produces URLs
+ * that no image server can resolve.
+ *
+ * Encoding first and then collapsing `%25XX` back to `%XX` leaves existing
+ * escape sequences untouched while still encoding characters that need it
+ * (spaces, non-ASCII, ...).
+ */
+function encodeURIPreservingEscapes(value: string) {
+  return encodeURI(value).replace(/%25([0-9A-Fa-f]{2})/g, "%$1");
+}
+
 function mintNewIdFromResource(
   resource: Presentation3.SomeRequired<Presentation2.TechnicalProperties, "@type">,
   subResource?: string
 ) {
-  const origId = encodeURI((resource as { id?: string }).id || resource["@id"] || "").trim();
+  const origId = encodeURIPreservingEscapes((resource as { id?: string }).id || resource["@id"] || "").trim();
 
   if (origId && subResource) {
     return `${origId}/${subResource}`;


### PR DESCRIPTION
## Problem

`convertPresentation2` produces image URLs that no image server can resolve when the Presentation 2 manifest uses percent-encoded identifiers.

`mintNewIdFromResource` passes the incoming id through `encodeURI`. Since `encodeURI` escapes a literal `%`, applying it to an identifier that is *already* percent-encoded turns `%2F` into `%252F`.

IIIF Image API identifiers commonly encode a slash inside the identifier as `%2F` (e.g. `book%2Fpage%2F0001.tif`), so this affects a lot of real manifests.

The symptom is confusing to diagnose: `service` is upgraded through a different path and keeps its original id, so viewers driven by the Image API service work fine, while anything reading the annotation body id directly (thumbnail pipelines, simple viewers, harvesters, validators) gets a 404.

Also note that in practice the short-circuit in `technicalProperties`

```ts
id: (resource["@id"] || mintNewIdFromResource(resource)).trim(),
```

does not help, because `@id` has already been normalised to `id` by the time the content resource is upgraded — so `mintNewIdFromResource` is always reached.

## Reproduction

Reproduces on `4.0.0` (and on `2.x`).

```js
import { convertPresentation2 } from '@iiif/parser/presentation-2'

const serviceId = 'https://example.org/iiif/3/book%2Fpage%2F0001.tif'
const imageId = `${serviceId}/full/max/0/default.jpg`

const out = convertPresentation2({
  '@context': 'http://iiif.io/api/presentation/2/context.json',
  '@id': 'https://example.org/manifest',
  '@type': 'sc:Manifest',
  label: 'test',
  sequences: [{
    '@id': 'https://example.org/sequence', '@type': 'sc:Sequence',
    canvases: [{
      '@id': 'https://example.org/canvas/1', '@type': 'sc:Canvas',
      label: '1', width: 1000, height: 1000,
      images: [{
        '@id': 'https://example.org/annotation/1', '@type': 'oa:Annotation',
        motivation: 'sc:painting', on: 'https://example.org/canvas/1',
        resource: {
          '@id': imageId, '@type': 'dctypes:Image', format: 'image/jpeg',
          width: 1000, height: 1000,
          service: {
            '@context': 'http://iiif.io/api/image/2/context.json',
            '@id': serviceId,
            profile: 'http://iiif.io/api/image/2/level2.json',
          },
        },
      }],
    }],
  }],
})

const body = out.items[0].items[0].items[0].body
console.log(body.id)
// actual:   https://example.org/iiif/3/book%252Fpage%252F0001.tif/full/max/0/default.jpg  -> 404
// expected: https://example.org/iiif/3/book%2Fpage%2F0001.tif/full/max/0/default.jpg
console.log(body.service[0]['@id'])
// https://example.org/iiif/3/book%2Fpage%2F0001.tif   (correct — hence the confusing symptom)
```

## Fix

Encode first, then collapse `%25XX` back to `%XX`. Existing escape sequences survive, and characters that genuinely need encoding are still handled.

```ts
function encodeURIPreservingEscapes(value: string) {
  return encodeURI(value).replace(/%25([0-9A-Fa-f]{2})/g, "%$1");
}
```

| input | before | after |
| --- | --- | --- |
| `a%2Fb.tif` | `a%252Fb.tif` (broken) | `a%2Fb.tif` |
| `a b.tif` | `a%20b.tif` | `a%20b.tif` (unchanged) |
| `資料.tif` | `%E8%B3%87%E6%96%99.tif` | unchanged |

The one case this deliberately does not handle is an identifier containing a literal, unescaped `%` immediately followed by two hex digits — that string is ambiguous, and treating it as an existing escape is the reading that keeps valid IIIF identifiers working.

## Tests

Two regression tests added to `__tests__/presentation-2-parser/upgrade.test.ts`:

- `does not double-encode percent-escaped identifiers` — fails without the fix (`expected 'book%252Fpage…' to deeply equal 'book%2Fpage…'`)
- `still encodes characters that are not escaped` — guards against over-correcting

Verified locally: `vitest run` → **486 tests / 39 files passing**, plus `oxfmt --check` and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
